### PR TITLE
Support serializing

### DIFF
--- a/slicerator.py
+++ b/slicerator.py
@@ -152,7 +152,7 @@ class Slicerator(object):
 
     def __getstate__(self):
         # When serializing, return a list of the sliced and processed data
-        return [self._get(key) for key in self._indices]
+        return [self._get(key) for key in self.indices]
 
     def __setstate__(self, data_as_list):
         # When deserializing, restore the Slicerator

--- a/slicerator.py
+++ b/slicerator.py
@@ -122,19 +122,20 @@ class Slicerator(object):
                     indices = _index_generator(rel_indices, abs_indices)
                     new_length = sum(key)
                     return Slicerator(self._ancestor, indices, new_length)
-            if any(_k < -_len or _k >= _len for _k in key):
-                raise IndexError("Keys out of range")
             try:
                 new_length = len(key)
             except TypeError:
                 # The key is a generator; return a plain old generator.
                 # Without knowing the length of the *key*,
                 # we can't give a Slicerator
+                # Also it cannot be checked if values are in range.
                 gen = (self[_k if _k >= 0 else _len + _k] for _k in key)
                 return gen
             else:
                 # The key is a list of in-range values. Build another
                 # Slicerator, again deferring computation.
+                if any(_k < -_len or _k >= _len for _k in key):
+                    raise IndexError("Keys out of range")
                 rel_indices = ((_k if _k >= 0 else _len + _k) for _k in key)
                 indices = _index_generator(rel_indices, abs_indices)
                 return Slicerator(self._ancestor, indices, new_length)

--- a/slicerator.py
+++ b/slicerator.py
@@ -9,7 +9,7 @@ from functools import wraps
 
 class Slicerator(object):
 
-    def __init__(self, ancestor, indices, length=None):
+    def __init__(self, ancestor, indices=None, length=None):
         """A generator that supports fancy indexing
 
         When sliced using any iterable with a known length, it return another
@@ -48,6 +48,12 @@ class Slicerator(object):
         >>> type(v3)
         generator
         """
+        if indices is None:
+            try:
+                indices = range(len(ancestor))
+            except TypeError:
+                raise ValueError("The indices parameter is required in this "
+                                 "case because len(ancestor) is not valid.")
         if length is None:
             try:
                 length = len(indices)

--- a/slicerator.py
+++ b/slicerator.py
@@ -149,6 +149,14 @@ class Slicerator(object):
                     abs_key = i
             return self._get(abs_key)
 
+    def __getstate__(self):
+        # When serializing, return a list of the sliced and processed data
+        return [self._get(key) for key in self._indices]
+
+    def __setstate__(self, data_as_list):
+        # When deserializing, restore the Slicerator
+        return self.__init__(data_as_list)
+
     def close(self):
         "Closing this child slice of the original reader does nothing."
         pass

--- a/tests.py
+++ b/tests.py
@@ -14,15 +14,14 @@ path = os.path.join(path, 'data')
 
 
 def assert_letters_equal(actual, expected):
+    # check if both lengths are equal
+    assert_equal(len(actual), len(expected))
     for actual_, expected_ in zip(actual, expected):
         assert_equal(actual_, expected_)
 
 
 def compare_slice_to_list(actual, expected):
     assert_letters_equal(actual, expected)
-    # test lengths
-    actual_len = len(actual)
-    assert_equal(actual_len, len(expected))
     indices = list(range(len(actual)))
     for i in indices:
         # test positive indexing
@@ -57,11 +56,7 @@ def compare_slice_to_list(actual, expected):
     assert_letters_equal(actual[:-1], expected[:-1])
 
 
-def letter_seq(letters):
-    return Slicerator(letters, list(range(len(letters))))
-
-
-v = letter_seq(list('abcdefghij'))
+v = Slicerator(list('abcdefghij'))
 
 
 def test_bool_mask():
@@ -137,8 +132,8 @@ def test_slice_of_slice_of_slice_of_slice():
 def test_slice_with_generator():
     slice1 = v[1:]
     compare_slice_to_list(slice1, list('bcdefghij'))
-    slice2 = slice1[(i for i in range(2,5))]
-    assert_letters_equal(slice2, list('def'))
+    slice2 = slice1[(i for i in range(2, 5))]
+    assert_letters_equal(list(slice2), list('def'))
     assert_true(isinstance(slice2, types.GeneratorType))
 
 


### PR DESCRIPTION
This is an attempt to solve https://github.com/soft-matter/pims/issues/178 . Pims still needs to be rebaced on slicerator though.

When serializing, I did the simplest thing you could do: serialize the actual data as a list, also applying the process_function. Then all the ancestors are lost. When unpickling, a Slicerator is constructed from a list of the actual data. This is mostly meant for multiprocessing.

This PR additionally makes `indices` an optional argument at `__init__`. It also fixes an issue with generator indexing.
