### PR TITLE
API/REF: Change how construction works.

### DIFF
--- a/slicerator.py
+++ b/slicerator.py
@@ -13,12 +13,14 @@ class Slicerator(object):
                  expose_attrs=None):
         """A generator that supports fancy indexing
 
-        When sliced using any iterable with a known length, it return another
+        When sliced using any iterable with a known length, it returns another
         object like itself, a Slicerator. When sliced with an integer,
         it returns the data payload.
 
-        Also, this retains the attributes of the ultimate ancestor that
-        created it (or its parent, or its parent's parent, ...).
+        Also, the attributes of the parent object can be propagated, exposed
+        through the child Slicerators. By default, no attributes are
+        propagated. But specific attributes to propagate can be white-listed
+        using the optional parameter `expose_attrs.
 
         Parameters
         ----------

--- a/slicerator.py
+++ b/slicerator.py
@@ -145,7 +145,7 @@ class Slicerator(object):
         attr = getattr(self._ancestor, key)
         if isinstance(attr, Slicerator):
             return Slicerator(attr, '__getitem__', self.indices, len(self),
-                              self._attrs)
+                              attr._attrs)
         else:
             return attr
 

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ import types
 import nose
 from six import BytesIO
 import pickle
-from nose.tools import assert_true, assert_equal, assert_raises
+from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 from slicerator import Slicerator, pipeline
 
 path, _ = os.path.split(os.path.abspath(__file__))
@@ -58,7 +58,7 @@ def compare_slice_to_list(actual, expected):
     assert_letters_equal(actual[:-1], expected[:-1])
 
 
-v = Slicerator(list('abcdefghij'))
+v = Slicerator.from_list(list('abcdefghij'))
 
 
 def test_bool_mask():
@@ -175,14 +175,17 @@ def test_repr():
 
 def test_getattr():
     class MyList(list):
-        my_attr = 'hello'
-        s = Slicerator(list('ABCDEFGHIJ'), range(10))
+        attr1 = 'hello'
+        attr2 = 'hello again'
+        s = Slicerator.from_list(list('ABCDEFGHIJ'))
+                       
 
-    a = Slicerator(MyList('abcdefghij'), range(10))
+    a = Slicerator.from_list(MyList('abcdefghij'), expose_attrs=['attr1', 's'])
     assert_letters_equal(a, list('abcdefghij'))
-    assert_true(hasattr(a, 'my_attr'))
+    assert_true(hasattr(a, 'attr1'))
+    assert_false(hasattr(a, 'attr2'))
     assert_true(hasattr(a, 's'))
-    assert_equal(a.my_attr, 'hello')
+    assert_equal(a.attr1, 'hello')
     with assert_raises(AttributeError):
         a[:5].nonexistent_attr
 


### PR DESCRIPTION
## Ways to constructor a Slicerator
1. From a function (any callable) that accepts an integer argument
   
   The length must be specified.
   
   ```
   Slicerator.from_func(func, 10)
   ```
2. From a list or any object that supports `__getitem__` and `__len__`
   
   ```
   Slicerator.from_list([1,2,3])
   ```
3. From an object with a method that accepts an integer argument
   
   ```
   Slicerator(obj, 'method_name')
   ```

Any of these "constructors" take an optional argument, `expose_attrs`, a whitelist of attributes that will be propagated through the Slicerator and its children. In a later PR, the pipeline decorator might let the user blacklist attributes that a pipeline invalidates. For example, a pipeline that crops should not propagate the original `frame_shape` attr.

For simplicity, the convenience constructors (1 and 2) take no other arguments. The `__init__` (3) takes a couple others, which Slicerators use to create child Slicerators.

Discuss! @caspervdw @tacaswell @nkeim 
