### PR TITLE
ENH/API Construction with decorator & attribute propagation

### DIFF
--- a/slicerator.py
+++ b/slicerator.py
@@ -84,7 +84,6 @@ class Slicerator(object):
         self._indices = indices
         self._propagate = propagate
         self._propagate_indexed = propagate_indexed
-        self._counter = 0
         self._proc_func = lambda image: image
 
     @classmethod
@@ -215,10 +214,6 @@ class Slicerator(object):
     def __setstate__(self, data_as_list):
         # When deserializing, restore the Slicerator
         return self.__init__(data_as_list, '__getitem__')
-
-    def close(self):
-        "Closing this child slice of the original reader does nothing."
-        pass
 
 
 def _index_generator(new_indices, old_indices):

--- a/slicerator.py
+++ b/slicerator.py
@@ -13,12 +13,14 @@ class Slicerator(object):
                  expose_attrs=None):
         """A generator that supports fancy indexing
 
-        When sliced using any iterable with a known length, it return another
+        When sliced using any iterable with a known length, it returns another
         object like itself, a Slicerator. When sliced with an integer,
         it returns the data payload.
 
-        Also, this retains the attributes of the ultimate ancestor that
-        created it (or its parent, or its parent's parent, ...).
+        Also, the attributes of the parent object can be propagated, exposed
+        through the child Slicerators. By default, no attributes are
+        propagated. But specific attributes to propagate can be white-listed
+        using the optional parameter `expose_attrs.
 
         Parameters
         ----------

--- a/slicerator.py
+++ b/slicerator.py
@@ -160,7 +160,7 @@ class Slicerator(object):
         return cls(Dummy(), propagated_attrs=propagated_attrs)
 
     @classmethod
-    def from_class(cls, other_class):
+    def from_class(cls, other_class, propagated_attrs=None):
         getitem = other_class.__getitem__
         @wraps(getitem)
         def wrapper(obj, key):
@@ -170,7 +170,7 @@ class Slicerator(object):
                 indices, new_length = key_to_indices(key, len(obj))
                 if new_length is None:
                     return wrapper(obj, (k for k in indices))
-                return cls(obj, indices, new_length)
+                return cls(obj, indices, new_length, propagated_attrs)
 
         setattr(other_class, '__getitem__', wrapper)
         setattr(other_class, '_is_slicerator', True)

--- a/slicerator.py
+++ b/slicerator.py
@@ -7,50 +7,9 @@ import itertools
 from functools import wraps
 
 
-class SliceableAttribute(object):
-    def __init__(self, slicerator, attribute):
-        self._ancestor = slicerator._ancestor
-        self._len = slicerator._len
-        self._get = attribute
-        self._indices = slicerator._indices
-
-    @property
-    def indices(self):
-        # Advancing indices won't affect this new copy of self._indices.
-        indices, self._indices = itertools.tee(iter(self._indices))
-        return indices
-
-    def _map_index(self, key):
-        if key < -self._len or key >= self._len:
-            raise IndexError("Key out of range")
-        try:
-            abs_key = self._indices[key]
-        except TypeError:
-            key = key if key >= 0 else self._len + key
-            for _, i in zip(range(key + 1), self.indices):
-                abs_key = i
-        return abs_key
-
-    def __iter__(self):
-        return (self._get(i) for i in self.indices)
-
-    def __len__(self):
-        return self._len
-
-    def __getitem__(self, key):
-        if not (isinstance(key, slice) or
-                isinstance(key, collections.Iterable)):
-            return self._get(self._map_index(key))
-        else:
-            rel_indices, new_length = key_to_indices(key, len(self))
-            return (self[k] for k in rel_indices)
-
-    __call__ = __getitem__
-
 class Slicerator(object):
-
-    def __init__(self, ancestor, indices=None,
-                 length=None, propagated_attrs=None):
+    def __init__(self, ancestor, indices=None, length=None,
+                 propagate_attrs=None):
         """A generator that supports fancy indexing
 
         When sliced using any iterable with a known length, it returns another
@@ -59,12 +18,12 @@ class Slicerator(object):
 
         Also, the attributes of the parent object can be propagated, exposed
         through the child Slicerators. By default, no attributes are
-        propagated. But specific attributes to propagate can be white-listed
-        using the optional parameter `propagated_attrs`.
+        propagated. Attributes can be white_listed by using the optional
+        parameter `propagated_attrs`.
 
         Class methods taking an index will be remapped if they are decorated
-        with `Slicerator.index_attr`. They also have to be present in the
-        `propagated_attrs` list.
+        with `index_attr`. They also have to be present in the
+        `propagate_attrs` list.
 
         Parameters
         ----------
@@ -76,9 +35,8 @@ class Slicerator(object):
             length of indicies
             This is required if `indices` is a generator,
             that is, if `len(indices)` is invalid
-        propagated_attrs : list of str, optional
+        propagate_attrs : list of str, optional
             list of attributes to be propagated into Slicerator
-            Overwrites contents of class propagated_attrs field and decorators.
 
         Examples
         --------
@@ -116,19 +74,19 @@ class Slicerator(object):
 
         # when list of propagated attributes are given explicitly,
         # take this list and ignore the class definition
-        if propagated_attrs is not None:
-            self.propagated_attrs = propagated_attrs
+        if propagate_attrs is not None:
+            self._propagate_attrs = propagate_attrs
         else:
             # check propagated_attrs field from the ancestor definition
-            if hasattr(ancestor, 'propagated_attrs'):
-                self.propagated_attrs = ancestor.propagated_attrs
+            if hasattr(ancestor, 'propagate_attrs'):
+                self._propagate_attrs = ancestor.propagate_attrs
             else:
-                self.propagated_attrs = []
+                self._propagate_attrs = []
 
             # add methods having the _propagate hook
             for name in dir(ancestor):
-                if hasattr(getattr(ancestor, name), '_propagate'):
-                    self.propagated_attrs.append(name)
+                if hasattr(getattr(ancestor, name), '_propagate_hook'):
+                    self._propagate_attrs.append(name)
 
         self._len = length
         self._ancestor = ancestor
@@ -136,7 +94,7 @@ class Slicerator(object):
         self._proc_func = lambda image: image
 
     @classmethod
-    def from_func(cls, func, length, propagated_attrs=None):
+    def from_func(cls, func, length, propagate_attrs=None):
         """
         Make a Slicerator from a function that accepts an integer index
 
@@ -146,7 +104,7 @@ class Slicerator(object):
             callable that accepts an integer as its argument
         length : int
             number of elements; used to supposed revserse slicing like [-1]
-        propagated_attrs : list, optional
+        propagate_attrs : list, optional
             list of attributes to be propagated into Slicerator
         """
         class Dummy:
@@ -157,12 +115,32 @@ class Slicerator(object):
             def __len__(self):
                 return length
 
-        return cls(Dummy(), propagated_attrs=propagated_attrs)
+        return cls(Dummy(), propagate_attrs=propagate_attrs)
 
     @classmethod
-    def from_class(cls, some_class, propagated_attrs=None):
-        """
-        Make an existing class support repeated slicing.
+    def from_class(cls, some_class, propagate_attrs=None):
+        """Make an existing class support fancy indexing via Slicerator objects.
+
+        When sliced using any iterable with a known length, it returns a
+        Slicerator. When sliced with an integer, it returns the data payload.
+
+        Also, the attributes of the parent object can be propagated, exposed
+        through the child Slicerators. By default, no attributes are
+        propagated. Attributes can be white_listed in the following ways:
+
+        1. using the optional parameter `propagate_attrs`; the contents of this
+           list will overwrite any other list of propagated attributes
+        2. using the @propagate_attr decorator inside the class definition
+        3. using a `propagate_attrs` class attribute inside the class definition
+
+        The difference between options 2 and 3 appears when subclassing. As
+        option 2 is bound to the method, the method will always be propagated.
+        On the contrary, option 3 is bound to the class, so this can be
+        overwritten by the subclass.
+
+        Class methods taking an index will be remapped if they are decorated
+        with `index_attr`. This decorator does not ensure that the method is
+        propagated.
 
         The existing class should support indexing (method __getitem__) and
         it should define a length (method __len__).
@@ -177,11 +155,14 @@ class Slicerator(object):
         some_class : class
         propagated_attrs : list, optional
             list of attributes to be propagated into Slicerator
+            this will overwrite any other propagation list
         """
 
         class Slicerator_subclass(some_class):
             _slicerator_hook = True
             _get = some_class.__getitem__
+            if hasattr(some_class, '__doc__'):
+                __doc__ = some_class.__doc__  # for Python 2, do it here
 
             def __getitem__(self, i):
                 """Getitem supports repeated slicing via Slicerator objects."""
@@ -191,32 +172,15 @@ class Slicerator(object):
                     indices, new_length = key_to_indices(i, len(self))
                     if new_length is None:
                         return self[(k for k in indices)]
-                    return cls(self, indices, new_length, propagated_attrs)
+                    return cls(self, indices, new_length, propagate_attrs)
 
-        for name in ['__doc__', '__name__', '__module__', '__repr__']:
+        for name in ['__name__', '__module__', '__repr__']:
             try:
                 setattr(Slicerator_subclass, name, getattr(some_class, name))
             except AttributeError:
                 pass
 
         return Slicerator_subclass
-
-    @classmethod
-    def index_attr(cls, func):
-        @wraps(func)
-        def wrapper(obj, key, *args, **kwargs):
-            indices = key_to_indices(key, len(obj))[0]
-            if isinstance(indices, collections.Iterable):
-                return (func(obj, i, *args, **kwargs) for i in indices)
-            else:
-                return func(obj, indices, *args, **kwargs)
-        wrapper._indexed = True
-        return wrapper
-
-    @classmethod
-    def propagate_attr(cls, func):
-        func._propagate = True
-        return func
 
     @property
     def indices(self):
@@ -262,15 +226,15 @@ class Slicerator(object):
                 return (self[k] for k in rel_indices)
             indices = _index_generator(rel_indices, self.indices)
             return Slicerator(self._ancestor, indices,
-                              new_length, self.propagated_attrs)
+                              new_length, self._propagate_attrs)
 
     def __getattr__(self, name):
         # to avoid infinite recursion, always check if public field is there
-        if 'propagated_attrs' not in self.__dict__:
-            self.propagated_attrs = []
-        if name in self.propagated_attrs:
+        if '_propagate_attrs' not in self.__dict__:
+            self._propagate_attrs = []
+        if name in self._propagate_attrs:
             attr = getattr(self._ancestor, name)
-            if hasattr(attr, '_indexed'):
+            if hasattr(attr, '_index_hook'):
                 return SliceableAttribute(self, getattr(self._ancestor, name))
             else:
                 return getattr(self._ancestor, name)
@@ -287,47 +251,60 @@ class Slicerator(object):
 
 
 def key_to_indices(key, length):
+    """Converts a fancy key into a list of indices.
+
+    Parameters
+    ----------
+    key : slice, iterable of numbers, or boolean mask
+    length : integer
+        length of object that will be indexed
+
+    Returns
+    -------
+    indices, new_length
+    """
     if isinstance(key, slice):
+        # if we have a slice, return a range object returning the indices
         start, stop, step = key.indices(length)
-        rel_indices = range(start, stop, step)
-        return rel_indices, len(rel_indices)
+        indices = range(start, stop, step)
+        return indices, len(indices)
 
     if isinstance(key, collections.Iterable):
         # if the input is an iterable, doing 'fancy' indexing
         if hasattr(key, '__array__') and hasattr(key, 'dtype'):
             if key.dtype == bool:
-                # if we have a bool array, set up masking but defer
-                # the actual computation, returning another Slicerator
+                # if we have a bool array, set up masking and return indices
                 nums = range(length)
                 # This next line fakes up numpy's bool masking without
                 # importing numpy.
-                rel_indices = [x for x, y in zip(nums, key) if y]
-                return rel_indices, sum(key)
+                indices = [x for x, y in zip(nums, key) if y]
+                return indices, sum(key)
         try:
             new_length = len(key)
         except TypeError:
             # The key is a generator; return a plain old generator.
-            # Without knowing the length of the *key*,
-            # we can't give a Slicerator
+            # Withoug using the generator, we cannot know its length.
             # Also it cannot be checked if values are in range.
             gen = ((_k if _k >= 0 else length + _k) for _k in key)
             return gen, None
         else:
-            # The key is a list of in-range values. Build another
-            # Slicerator, again deferring computation.
+            # The key is a list of in-range values. Check if they are in range.
             if any(_k < -length or _k >= length for _k in key):
                 raise IndexError("Keys out of range")
             rel_indices = ((_k if _k >= 0 else length + _k) for _k in key)
             return rel_indices, new_length
 
+    # other cases: it's possibly a number
     try:
+        key = int(key)
+    except TypeError:
+        pass
+    else:
         # allow negative indexing
         if -length < key < 0:
             return length + key, None
-    except TypeError:
-        pass
 
-    # in all other case, just return the key and let user handle TypeErrors
+    # in all other case, just return the key and let user deal with the type.
     return key, None
 
 
@@ -426,3 +403,68 @@ def pipeline(func):
                        "any other objects, its behavior is "
                        "unchanged.\n\n") + process.__doc__
     return process
+
+
+def propagate_attr(func):
+    func._propagate_hook = True
+    return func
+
+
+def index_attr(func):
+    @wraps(func)
+    def wrapper(obj, key, *args, **kwargs):
+        indices = key_to_indices(key, len(obj))[0]
+        if isinstance(indices, collections.Iterable):
+            return (func(obj, i, *args, **kwargs) for i in indices)
+        else:
+            return func(obj, indices, *args, **kwargs)
+    wrapper._index_hook = True
+    return wrapper
+
+
+class SliceableAttribute(object):
+    """This class enables index-taking methods that are linked to a Slicerator
+    object to remap their indices according to the Slicerator indices.
+
+    It also enables fancy indexing, exactly like the Slicerator itself. The new
+    attribute supports both calling and indexing to give identical results."""
+
+    def __init__(self, slicerator, attribute):
+        self._ancestor = slicerator._ancestor
+        self._len = slicerator._len
+        self._get = attribute
+        self._indices = slicerator._indices
+
+    @property
+    def indices(self):
+        # Advancing indices won't affect this new copy of self._indices.
+        indices, self._indices = itertools.tee(iter(self._indices))
+        return indices
+
+    def _map_index(self, key):
+        if key < -self._len or key >= self._len:
+            raise IndexError("Key out of range")
+        try:
+            abs_key = self._indices[key]
+        except TypeError:
+            key = key if key >= 0 else self._len + key
+            for _, i in zip(range(key + 1), self.indices):
+                abs_key = i
+        return abs_key
+
+    def __iter__(self):
+        return (self._get(i) for i in self.indices)
+
+    def __len__(self):
+        return self._len
+
+    def __call__(self, key, *args, **kwargs):
+        if not (isinstance(key, slice) or
+                isinstance(key, collections.Iterable)):
+            return self._get(self._map_index(key), *args, **kwargs)
+        else:
+            rel_indices, new_length = key_to_indices(key, len(self))
+            return (self[k] for k in rel_indices)
+
+    def __getitem__(self, key):
+        return self(key)

--- a/slicerator.py
+++ b/slicerator.py
@@ -7,6 +7,15 @@ import itertools
 from functools import wraps
 
 
+def _iter_attr(obj):
+    try:
+        for ns in [obj] + obj.__class__.mro():
+            for attr in ns.__dict__:
+                yield ns.__dict__[attr]
+    except AttributeError:
+        raise StopIteration  # obj has no __dict__
+
+
 class Slicerator(object):
     def __init__(self, ancestor, indices=None, length=None,
                  propagate_attrs=None, proc_func=None):
@@ -88,9 +97,9 @@ class Slicerator(object):
                 self._propagate_attrs = []
 
             # add methods having the _propagate hook
-            for name in dir(ancestor):
-                if hasattr(getattr(ancestor, name), '_propagate_hook'):
-                    self._propagate_attrs.append(name)
+            for attr in _iter_attr(ancestor):
+                if hasattr(attr, '_propagate_hook'):
+                    self._propagate_attrs.append(attr.__name__)
 
         self._len = length
         self._ancestor = ancestor

--- a/slicerator.py
+++ b/slicerator.py
@@ -341,7 +341,7 @@ class slicerate(object):
     def __call__(self, getitem):
         def slicerated(obj, key):
             if isinstance(key, int):
-                return getitem(obj, key)
+                return getitem(obj, key if key >= 0 else len(obj) + key)
             else:
                 return Slicerator(obj, '__getitem__',
                                   slice_attrs=self.slice_attrs,

--- a/slicerator.py
+++ b/slicerator.py
@@ -173,12 +173,10 @@ class Slicerator(object):
 
             def __getitem__(self, i):
                 """Getitem supports repeated slicing via Slicerator objects."""
-                if isinstance(i, int):
-                    return self._get(i if i >= 0 else len(self) + i)
+                indices, new_length = key_to_indices(i, len(self))
+                if new_length is None:
+                    return self._get(indices)
                 else:
-                    indices, new_length = key_to_indices(i, len(self))
-                    if new_length is None:
-                        return self[(k for k in indices)]
                     return cls(self, indices, new_length, propagate_attrs)
 
         for name in ['__name__', '__module__', '__repr__']:

--- a/slicerator.py
+++ b/slicerator.py
@@ -7,10 +7,50 @@ import itertools
 from functools import wraps
 
 
+class SliceableAttribute(object):
+    def __init__(self, slicerator, attribute):
+        self._ancestor = slicerator._ancestor
+        self._len = slicerator._len
+        self._get = attribute
+        self._indices = slicerator._indices
+
+    @property
+    def indices(self):
+        # Advancing indices won't affect this new copy of self._indices.
+        indices, self._indices = itertools.tee(iter(self._indices))
+        return indices
+
+    def _map_index(self, key):
+        if key < -self._len or key >= self._len:
+            raise IndexError("Key out of range")
+        try:
+            abs_key = self._indices[key]
+        except TypeError:
+            key = key if key >= 0 else self._len + key
+            for _, i in zip(range(key + 1), self.indices):
+                abs_key = i
+        return abs_key
+
+    def __iter__(self):
+        return (self._get(i) for i in self.indices)
+
+    def __len__(self):
+        return self._len
+
+    def __getitem__(self, key):
+        if not (isinstance(key, slice) or
+                isinstance(key, collections.Iterable)):
+            return self._get(self._map_index(key))
+        else:
+            rel_indices, new_length = key_to_indices(key, len(self))
+            return (self[k] for k in rel_indices)
+
+    __call__ = __getitem__
+
 class Slicerator(object):
 
     def __init__(self, ancestor, method='__getitem__', indices=None,
-                 length=None, propagate=None, propagate_indexed=None):
+                 length=None, propagated_attrs=None):
         """A generator that supports fancy indexing
 
         When sliced using any iterable with a known length, it returns another
@@ -20,8 +60,11 @@ class Slicerator(object):
         Also, the attributes of the parent object can be propagated, exposed
         through the child Slicerators. By default, no attributes are
         propagated. But specific attributes to propagate can be white-listed
-        using the optional parameter `propagate`. Class methods taking an index
-        can be propagated using `propagate_indexed`. The index will be remapped.
+        using the optional parameter `propagated_attrs`.
+
+        Class methods taking an index will be remapped if they are decorated
+        with `Slicerator.index_attr`. They also have to be present in the
+        `propagated_attrs` list.
 
         Parameters
         ----------
@@ -36,13 +79,9 @@ class Slicerator(object):
         method : string, optional
             method of ancestor object that accept an integer as its argument.
             Defaults to '__getitem__'.
-        propagate : list of str, optional
+        propagated_attrs : list of str, optional
             list of attributes to be propagated into Slicerator
-            May also be defined using the @propagate decorator
-        propagate_indexed : list of str, optional
-            list of class methods to be propagated into Slicerator. Slicerator
-            will remap the first argument of the method to the index in the
-            slice. May also be defined using the @propagate_indexed decorator
+            Overwrites contents of class propagated_attrs field and decorators.
 
         Examples
         --------
@@ -74,20 +113,31 @@ class Slicerator(object):
             except TypeError:
                 raise ValueError("The length parameter is required in this "
                                  "case because len(indices) is not valid.")
-        if propagate_indexed is None:
-            propagate_indexed = []
-        if propagate is None:
-            propagate = []
+
+        # when list of propagated attributes are given explicitly,
+        # take this list and ignore the class definition
+        if propagated_attrs is not None:
+            self.propagated_attrs = propagated_attrs
+        else:
+            # check propagated_attrs field from the ancestor definition
+            if hasattr(ancestor, 'propagated_attrs'):
+                self.propagated_attrs = ancestor.propagated_attrs
+            else:
+                self.propagated_attrs = []
+
+            # add methods having the _propagate hook
+            for name in dir(ancestor):
+                if hasattr(getattr(ancestor, name), '_propagate'):
+                    self.propagated_attrs.append(name)
+
         self._len = length
         self._ancestor = ancestor
         self._method = method
         self._indices = indices
-        self._propagate = propagate
-        self._propagate_indexed = propagate_indexed
         self._proc_func = lambda image: image
 
     @classmethod
-    def from_func(cls, func, length, propagate=None):
+    def from_func(cls, func, length, propagated_attrs=None):
         """
         Make a Slicerator from a function that accepts an integer index
 
@@ -97,46 +147,52 @@ class Slicerator(object):
             callable that accepts an integer as its argument
         length : int
             number of elements; used to supposed revserse slicing like [-1]
-        propagate : list, optional
-            list of attributes to be propaged into Slicerator
+        propagated_attrs : list, optional
+            list of attributes to be propagated into Slicerator
         """
         class Dummy:
 
-            def __getitem__(self):
-                return func
+            def __getitem__(self, i):
+                return func(i)
 
             def __len__(self):
                 return length
 
-        return cls(Dummy(), propagate=propagate)
+        return cls(Dummy(), propagated_attrs=propagated_attrs)
 
     @classmethod
     def from_class(cls, other_class):
-        if hasattr(other_class, 'propagate'):
-            propagate = other_class.propagate
-        else:
-            propagate = []
-
-        if hasattr(other_class, 'propagate_indexed'):
-            propagate_indexed = other_class.propagate_indexed
-        else:
-            propagate_indexed = []
-
         getitem = other_class.__getitem__
         @wraps(getitem)
         def wrapper(obj, key):
             if isinstance(key, int):
                 return getitem(obj, key if key >= 0 else len(obj) + key)
             else:
-                indices, new_length = fancy_indexing(key, len(obj))
+                indices, new_length = key_to_indices(key, len(obj))
                 if new_length is None:
                     return wrapper(obj, (k for k in indices))
-                return cls(obj, '__getitem__', indices, new_length,
-                           propagate, propagate_indexed)
+                return cls(obj, '__getitem__', indices, new_length)
 
         setattr(other_class, '__getitem__', wrapper)
-        setattr(other_class, 'is_slicerator', True)
+        setattr(other_class, '_is_slicerator', True)
         return other_class
+
+    @classmethod
+    def index_attr(cls, func):
+        @wraps(func)
+        def wrapper(obj, key, *args, **kwargs):
+            indices = key_to_indices(key, len(obj))[0]
+            if isinstance(indices, collections.Iterable):
+                return (func(obj, i, *args, **kwargs) for i in indices)
+            else:
+                return func(obj, indices, *args, **kwargs)
+        wrapper._indexed = True
+        return wrapper
+
+    @classmethod
+    def propagate_attr(cls, func):
+        func._propagate = True
+        return func
 
     @property
     def indices(self):
@@ -173,26 +229,27 @@ class Slicerator(object):
 
     def __getitem__(self, key):
         """for data access"""
-        if isinstance(key, int):
+        if not (isinstance(key, slice) or
+                isinstance(key, collections.Iterable)):
             return self._get(self._map_index(key))
         else:
-            rel_indices, new_length = fancy_indexing(key, len(self))
+            rel_indices, new_length = key_to_indices(key, len(self))
             if new_length is None:
                 return (self[k] for k in rel_indices)
             indices = _index_generator(rel_indices, self.indices)
-            return Slicerator(self._ancestor, '__getitem__', indices, new_length,
-                              self._propagate, self._propagate_indexed)
+            return Slicerator(self._ancestor, '__getitem__', indices,
+                              new_length, self.propagated_attrs)
 
     def __getattr__(self, name):
-        if not hasattr(self._ancestor, name):
-            raise AttributeError
-        attr = getattr(self._ancestor, name)
-        if name in self._propagate or hasattr(attr, '_propagate'):
-            return attr
-        if name in self._propagate_indexed or hasattr(attr, '_propagate_indexed'):
-            def attr_reindexed(key, *args, **kwargs):
-                return attr(self._map_index(key), *args, **kwargs)
-            return attr_reindexed
+        # to avoid infinite recursion, always check if public field is there
+        if 'propagated_attrs' not in self.__dict__:
+            self.propagated_attrs = []
+        if name in self.propagated_attrs:
+            attr = getattr(self._ancestor, name)
+            if hasattr(attr, '_indexed'):
+                return SliceableAttribute(self, getattr(self._ancestor, name))
+            else:
+                return getattr(self._ancestor, name)
         raise AttributeError
 
     def __getstate__(self):
@@ -205,12 +262,13 @@ class Slicerator(object):
         return self.__init__(data_as_list, '__getitem__')
 
 
-def fancy_indexing(key, length):
+def key_to_indices(key, length):
     if isinstance(key, slice):
         start, stop, step = key.indices(length)
         rel_indices = range(start, stop, step)
         return rel_indices, len(rel_indices)
-    elif isinstance(key, collections.Iterable):
+
+    if isinstance(key, collections.Iterable):
         # if the input is an iterable, doing 'fancy' indexing
         if hasattr(key, '__array__') and hasattr(key, 'dtype'):
             if key.dtype == bool:
@@ -237,15 +295,16 @@ def fancy_indexing(key, length):
                 raise IndexError("Keys out of range")
             rel_indices = ((_k if _k >= 0 else length + _k) for _k in key)
             return rel_indices, new_length
-    else:
-        if key < -length or key >= length:
-            raise IndexError("Key out of range")
-        if key >= 0:
-            return key, None
-        else:
-            return length + key, None
 
-    raise ValueError("Unknown key type '{}'.".format(type(key)))
+    try:
+        # allow negative indexing
+        if -length < key < 0:
+            return length + key, None
+    except TypeError:
+        pass
+
+    # in all other case, just return the key and let user handle TypeErrors
+    return key, None
 
 
 def _index_generator(new_indices, old_indices):
@@ -282,7 +341,7 @@ def _index_generator(new_indices, old_indices):
                 continue
 
 
-class pipeline(object):
+def pipeline(func):
     """Decorator to make function aware of Slicerator objects.
 
     When the function is applied to a Slicerator, it
@@ -291,15 +350,6 @@ class pipeline(object):
     When the function is applied to any other object, it falls back on its
     normal behavhior.
 
-    Parameters
-    ----------
-    propagate : list of str
-        List of attribute names that will be propagated through the pipeline.
-    propagate_indexed : list of str
-        List of attribute names that will be propagated and reindexed through
-        the pipeline. Attributes need to be methods accepting an index as its
-        second argument (so directly after `self`).
-
     Returns
     -------
     processed_images : Slicerator
@@ -307,7 +357,7 @@ class pipeline(object):
     Example
     -------
     Apply the pipeline decorator to your image processing function.
-    >>> @pipeline()
+    >>> @pipeline
     ...  def color_channel(image, channel):
     ...      return image[channel, :, :]
     ...
@@ -320,7 +370,7 @@ class pipeline(object):
     >>> green_images = color_channel(images, 1)
 
     Pipeline functions can also be composed.
-    >>> @pipeline()
+    >>> @pipeline
     ... def rescale(image):
     ... return (image - image.min())/image.ptp()
     ...
@@ -331,34 +381,24 @@ class pipeline(object):
     >>> single_img = images[0]
     >>> red_img = red_channel(single_img)  # normal behavior
     """
-    def __init__(self, propagate=None, propagate_indexed=None):
-        if callable(propagate):
-            # When decorator is used without (), the first parameter will be
-            # the decorated function itself.
-            raise ValueError('The decorator @pipeline requires arguments. Put '
-                             '() if you do not want to propagate attributes.')
-        self.propagate = propagate
-        self.propagate_indexed = propagate_indexed
+    @wraps(func)
+    def process(obj, *args, **kwargs):
+        if hasattr(obj, '_is_slicerator') or isinstance(obj, Slicerator):
+            s = Slicerator(obj)
+            def f(x):
+                return func(x, *args, **kwargs)
+            s._proc_func = f
+            return s
+        else:
+            # Fall back on normal behavior of func, interpreting input
+            # as a single image.
+            return func(obj, *args, **kwargs)
 
-    def __call__(self, func):
-        @wraps(func)
-        def process(obj, *args, **kwargs):
-            if hasattr(obj, 'is_slicerator') or isinstance(obj, Slicerator):
-                s = Slicerator(obj, propagate=self.propagate,
-                               propagate_indexed=self.propagate_indexed)
-                def f(x):
-                    return func(x, *args, **kwargs)
-                s._proc_func = f
-                return s
-            else:
-                # Fall back on normal behavior of func, interpreting input
-                # as a single image.
-                return func(obj, *args, **kwargs)
-        if process.__doc__ is None:
-            process.__doc__ = ''
-        process.__doc__ = ("This function has been made lazy. When passed\n"
-                           "a Slicerator, it will return a \n"
-                           "new Slicerator of the results. When passed \n"
-                           "any other objects, its behavior is "
-                           "unchanged.\n\n") + process.__doc__
-        return process
+    if process.__doc__ is None:
+        process.__doc__ = ''
+    process.__doc__ = ("This function has been made lazy. When passed\n"
+                       "a Slicerator, it will return a \n"
+                       "new Slicerator of the results. When passed \n"
+                       "any other objects, its behavior is "
+                       "unchanged.\n\n") + process.__doc__
+    return process

--- a/slicerator.py
+++ b/slicerator.py
@@ -145,7 +145,7 @@ class Slicerator(object):
         attr = getattr(self._ancestor, key)
         if isinstance(attr, Slicerator):
             return Slicerator(attr, '__getitem__', self.indices, len(self),
-                              self._attrs)
+                              attr._attrs)
         else:
             return attr
 

--- a/tests.py
+++ b/tests.py
@@ -181,6 +181,8 @@ def test_getattr():
         def s(self, i):
             return list('ABCDEFGHIJ')[i]
 
+        def close(self):
+            pass
 
     a = Slicerator(MyList('abcdefghij'), propagate=['attr1'],
                    propagate_indexed=['s'])
@@ -188,6 +190,7 @@ def test_getattr():
     assert_true(hasattr(a, 'attr1'))
     assert_false(hasattr(a, 'attr2'))
     assert_true(hasattr(a, 's'))
+    assert_false(hasattr(a, 'close'))
     assert_equal(a.attr1, 'hello')
     with assert_raises(AttributeError):
         a[:5].nonexistent_attr

--- a/tests.py
+++ b/tests.py
@@ -391,6 +391,26 @@ def test_from_class():
     assert_letters_equal(cap_b, 'aBcdefghij')
 
 
+def test_lazy_hasattr():
+    # this ensures that the Slicerator init does not evaluate all properties
+    class Dummy(object):
+        """DocString"""
+        def __init__(self):
+            self.frame = list('abcdefghij')
+
+        def __len__(self):
+            return len(self.frame)
+
+        def __getitem__(self, i):
+            """Other Docstring"""
+            return self.frame[i]  # actual code of get_frame
+
+        @property
+        def forbidden_property(self):
+            raise RuntimeError()
+
+    DummySli = Slicerator.from_class(Dummy)
+
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
                    exit=False)

--- a/tests.py
+++ b/tests.py
@@ -174,6 +174,23 @@ def test_pipeline_simple():
     assert_letters_equal([cap_v[0]], [_capitalize(v[0])])
 
 
+def test_pipeline_propagation():
+    capitalize = pipeline(_capitalize)
+    cap_v = capitalize(v)
+
+    assert_letters_equal([cap_v[:1][0]], ['A'])
+    assert_letters_equal([cap_v[:1][:2][0]], ['A'])
+
+
+def test_pipeline_nesting():
+    capitalize = pipeline(_capitalize)
+    a_to_z = pipeline(_a_to_z)
+    nested_v = capitalize(a_to_z(v))
+
+    assert_letters_equal([nested_v[0]], ['Z'])
+    assert_letters_equal([nested_v[:1][0]], ['Z'])
+
+
 def test_repr():
     repr(v)
 

--- a/tests.py
+++ b/tests.py
@@ -338,8 +338,8 @@ def test_serialize():
 
 
 def test_from_class():
-    @Slicerator.from_class
     class Dummy(object):
+        """DocString"""
         def __init__(self):
             self.frame = list('abcdefghij')
 
@@ -347,10 +347,24 @@ def test_from_class():
             return len(self.frame)
 
         def __getitem__(self, i):
+            """Other Docstring"""
             return self.frame[i]  # actual code of get_frame
 
+        def __repr__(self):
+            return 'Repr'
 
-    dummy = Dummy()
+    DummySli = Slicerator.from_class(Dummy)
+    assert Dummy()[:2] == ['a', 'b']  # Dummy is unaffected
+
+    # class slots propagate
+    assert DummySli.__name__ == Dummy.__name__
+    assert DummySli.__doc__ == Dummy.__doc__
+    assert DummySli.__module__ == Dummy.__module__
+
+    dummy = DummySli()
+    assert isinstance(dummy, Dummy)  # still instance of Dummy
+    assert repr(dummy) == 'Repr'  # repr propagates
+
     compare_slice_to_list(dummy, 'abcdefghij')
     compare_slice_to_list(dummy[1:], 'bcdefghij')
     compare_slice_to_list(dummy[1:][2:], 'defghij')

--- a/tests.py
+++ b/tests.py
@@ -58,7 +58,7 @@ def compare_slice_to_list(actual, expected):
     assert_letters_equal(actual[:-1], expected[:-1])
 
 
-v = Slicerator.from_list(list('abcdefghij'))
+v = Slicerator(list('abcdefghij'))
 
 
 def test_bool_mask():
@@ -163,7 +163,7 @@ def _a_to_z(letter):
 
 
 def test_pipeline_simple():
-    capitalize = pipeline(_capitalize)
+    capitalize = pipeline()(_capitalize)
     cap_v = capitalize(v[:1])
 
     assert_letters_equal([cap_v[0]], [_capitalize(v[0])])
@@ -177,27 +177,30 @@ def test_getattr():
     class MyList(list):
         attr1 = 'hello'
         attr2 = 'hello again'
-     #   s = Slicerator.from_list(list('ABCDEFGHIJ'))
-                       
 
-    a = Slicerator.from_list(MyList('abcdefghij'), propagate=['attr1'])
+        def s(self, i):
+            return list('ABCDEFGHIJ')[i]
+
+
+    a = Slicerator(MyList('abcdefghij'), propagate=['attr1'],
+                   propagate_indexed=['s'])
     assert_letters_equal(a, list('abcdefghij'))
     assert_true(hasattr(a, 'attr1'))
     assert_false(hasattr(a, 'attr2'))
-   # assert_true(hasattr(a, 's'))
+    assert_true(hasattr(a, 's'))
     assert_equal(a.attr1, 'hello')
     with assert_raises(AttributeError):
         a[:5].nonexistent_attr
 
- #   s1 = a[::2].s
- #   assert_equal(list(s1), list('ACEGI'))
- #   s2 = a[::2][1:].s
- #   assert_equal(list(s2), list('CEGI'))
- #   assert_equal(a[::2][1:].s[0], 'C')
+    s1 = a[::2].s
+    assert_equal([s1(i) for i in range(5)], list('ACEGI'))
+    s2 = a[::2][1:].s
+    assert_equal([s2(i) for i in range(4)], list('CEGI'))
+    assert_equal(a[::2][1:].s(0), 'C')
 
 
 def test_pipeline_with_args():
-    capitalize = pipeline(_capitalize_if_equal)
+    capitalize = pipeline()(_capitalize_if_equal)
     cap_a = capitalize(v, 'a')
     cap_b = capitalize(v, 'b')
 
@@ -209,8 +212,8 @@ def test_pipeline_with_args():
 
 
 def test_composed_pipelines():
-    a_to_z = pipeline(_a_to_z)
-    capitalize = pipeline(_capitalize_if_equal)
+    a_to_z = pipeline()(_a_to_z)
+    capitalize = pipeline()(_capitalize_if_equal)
 
     composed = capitalize(a_to_z(v), 'c')
 
@@ -248,7 +251,7 @@ def test_serialize():
     compare_slice_to_list(v2[2:][:-1], list('gh'))
 
     # test pipeline
-    capitalize = pipeline(_capitalize_if_equal)
+    capitalize = pipeline()(_capitalize_if_equal)
     stream = BytesIO()
     pickle.dump(capitalize(v, 'a'), stream)
     stream.seek(0)
@@ -297,7 +300,7 @@ def test_class():
     assert_equal(dummy[1:][2:].filename, 'filename')
     assert_equal(dummy[1:][2:].other_attr(), 'other_string')
 
-    capitalize = pipeline(_capitalize_if_equal)
+    capitalize = pipeline()(_capitalize_if_equal)
     cap_b = capitalize(dummy, 'b')
     assert_letters_equal(cap_b, 'aBcdefghij')
 

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ import nose
 from six import BytesIO
 import pickle
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
-from slicerator import *
+from slicerator import Slicerator, pipeline
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -263,21 +263,22 @@ def test_serialize():
     compare_slice_to_list(v2, list('Abcdefghij'))
 
 def test_class():
+    @Slicerator.from_class
     class Dummy(object):
+        propagate_indexed = ['time', 'return_i']
+        propagate = ['filename', 'other_attr']
         def __init__(self):
             self.frame = list('abcdefghij')
 
         def __len__(self):
             return len(self.frame)
 
-        @slicerate(propagate_indexed=['time'], propagate=['filename'])
         def __getitem__(self, i):
             return self.frame[i]  # actual code of get_frame
 
         def time(self, i):
             return i * 5
 
-        @propagate_indexed
         def return_i(self, i):
             return i
 
@@ -285,7 +286,6 @@ def test_class():
         def filename(self):
             return 'filename'
 
-        @propagate
         def other_attr(self):
             return 'other_string'
 

--- a/tests.py
+++ b/tests.py
@@ -9,7 +9,7 @@ import nose
 from six import BytesIO
 import pickle
 from nose.tools import assert_true, assert_false, assert_equal, assert_raises
-from slicerator import Slicerator, pipeline
+from slicerator import Slicerator, pipeline, index_attr, propagate_attr
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -183,14 +183,14 @@ def test_getattr():
         attr1 = 'hello'
         attr2 = 'hello again'
 
-        @Slicerator.index_attr
+        @index_attr
         def s(self, i):
             return list('ABCDEFGHIJ')[i]
 
         def close(self):
             pass
 
-    a = Slicerator(MyList('abcdefghij'), propagated_attrs=['attr1', 's'])
+    a = Slicerator(MyList('abcdefghij'), propagate_attrs=['attr1', 's'])
     assert_letters_equal(a, list('abcdefghij'))
     assert_true(hasattr(a, 'attr1'))
     assert_false(hasattr(a, 'attr2'))
@@ -207,7 +207,7 @@ def test_getattr():
 def test_getattr_subclass():
     @Slicerator.from_class
     class Dummy(object):
-        propagated_attrs = ['attr1']
+        propagate_attrs = ['attr1']
         def __init__(self):
             self.frame = list('abcdefghij')
 
@@ -221,7 +221,7 @@ def test_getattr_subclass():
             # propagates through slices of Dummy
             return 'sliced'
 
-        @Slicerator.propagate_attr
+        @propagate_attr
         def attr2(self):
             # propagates through slices of Dummy and subclasses
             return 'also in subclasses'
@@ -232,7 +232,7 @@ def test_getattr_subclass():
 
 
     class SubClass(Dummy):
-        propagated_attrs = ['attr4']  # overwrites propagated attrs from Dummy
+        propagate_attrs = ['attr4']  # overwrites propagated attrs from Dummy
 
         def __len__(self):
             return len(self.frame)

--- a/tests.py
+++ b/tests.py
@@ -8,7 +8,7 @@ import types
 import nose
 from six import BytesIO
 import pickle
-from nose.tools import assert_true, assert_equal, assert_raises
+from nose.tools import assert_true, assert_false, assert_equal, assert_raises
 from slicerator import Slicerator, pipeline
 
 path, _ = os.path.split(os.path.abspath(__file__))
@@ -58,7 +58,7 @@ def compare_slice_to_list(actual, expected):
     assert_letters_equal(actual[:-1], expected[:-1])
 
 
-v = Slicerator(list('abcdefghij'))
+v = Slicerator.from_list(list('abcdefghij'))
 
 
 def test_bool_mask():
@@ -175,14 +175,17 @@ def test_repr():
 
 def test_getattr():
     class MyList(list):
-        my_attr = 'hello'
-        s = Slicerator(list('ABCDEFGHIJ'), range(10))
+        attr1 = 'hello'
+        attr2 = 'hello again'
+        s = Slicerator.from_list(list('ABCDEFGHIJ'))
+                       
 
-    a = Slicerator(MyList('abcdefghij'), range(10))
+    a = Slicerator.from_list(MyList('abcdefghij'), expose_attrs=['attr1', 's'])
     assert_letters_equal(a, list('abcdefghij'))
-    assert_true(hasattr(a, 'my_attr'))
+    assert_true(hasattr(a, 'attr1'))
+    assert_false(hasattr(a, 'attr2'))
     assert_true(hasattr(a, 's'))
-    assert_equal(a.my_attr, 'hello')
+    assert_equal(a.attr1, 'hello')
     with assert_raises(AttributeError):
         a[:5].nonexistent_attr
 

--- a/tests.py
+++ b/tests.py
@@ -278,19 +278,18 @@ def test_class():
             return self._filename
 
     dummy = Dummy()
-    assert_equal(dummy[1:][0], 'b')
+    compare_slice_to_list(dummy, 'abcdefghij')
+    compare_slice_to_list(dummy[1:], 'bcdefghij')
     assert_equal(dummy[1:].time(0), 1)
     assert_equal(dummy[1:].filename, 'filename')
 
-    assert_equal(dummy[1:][2:][0], 'd')
+    compare_slice_to_list(dummy[1:][2:], 'defghij')
     assert_equal(dummy[1:][2:].time(0), 3)
     assert_equal(dummy[1:][2:].filename, 'filename')
 
     capitalize = pipeline(_capitalize_if_equal)
     cap_b = capitalize(dummy, 'b')
-    assert_equal(cap_b[1], 'B')
-
-
+    assert_letters_equal(cap_b, 'aBcdefghij')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This continues the work of @danielballan in https://github.com/soft-matter/slicerator/pull/4, it adds a decorator to easily implement `Slicerator` in classes.

Also it fixes some issues with attribute propagation. It doesn't work with `__getattr__` anymore; propagated attributes are actually set to the Slicerator with `setattr` at construction. Attributes that are indexed (`slice_attrs`) will be wrapped applying `_map_index` to the index.

```
class Dummy(object):
    def __init__(self):
        self.frame = list('abcdefghij')
        self._time = list(range(len(self.frame)))
        self._filename = 'filename'

    def __len__(self):
        return len(self.frame)

    @slicerate(slice_attrs=['time'], expose_attrs=['filename'])
    def __getitem__(self, i):
        return self.frame[i]  # actual code of get_frame

    def time(self, i):
        return self._time[i]

    @property
    def filename(self):
        return self._filename
```
