### PR TITLE
FIX Propagation of indexed attributes

### DIFF
--- a/slicerator.py
+++ b/slicerator.py
@@ -259,7 +259,7 @@ class Slicerator(object):
                     hasattr(attr, '_index_flag')):
                 return SliceableAttribute(self, attr)
             else:
-                return getattr(self._ancestor, name)
+                return attr
         raise AttributeError
 
     def __getstate__(self):

--- a/slicerator.py
+++ b/slicerator.py
@@ -255,8 +255,9 @@ class Slicerator(object):
             self._propagate_attrs = []
         if name in self._propagate_attrs:
             attr = getattr(self._ancestor, name)
-            if hasattr(attr, '_index_flag'):
-                return SliceableAttribute(self, getattr(self._ancestor, name))
+            if (isinstance(attr, SliceableAttribute) or
+                    hasattr(attr, '_index_flag')):
+                return SliceableAttribute(self, attr)
             else:
                 return getattr(self._ancestor, name)
         raise AttributeError
@@ -452,7 +453,7 @@ class SliceableAttribute(object):
         self._ancestor = slicerator._ancestor
         self._len = slicerator._len
         self._get = attribute
-        self._indices = slicerator._indices
+        self._indices = slicerator.indices  # make an independent copy
 
     @property
     def indices(self):

--- a/tests.py
+++ b/tests.py
@@ -229,6 +229,7 @@ def test_getattr():
     with assert_raises(AttributeError):
         a[:5].nonexistent_attr
 
+    compare_slice_to_list(list(a.s), list('ABCDEFGHIJ'))
     compare_slice_to_list(list(a[::2].s), list('ACEGI'))
     compare_slice_to_list(list(a[::2][1:].s), list('CEGI'))
 
@@ -243,10 +244,9 @@ def test_getattr():
     with assert_raises(AttributeError):
         b[:5].nonexistent_attr
 
-    # TODO: propagation of indexed attributes does not work.
-    # Disable tests for now.
-    # compare_slice_to_list(list(b[::2].s), list('ACEGI'))
-    # compare_slice_to_list(list(b[::2][1:].s), list('CEGI'))
+    compare_slice_to_list(list(b.s), list('ABCDEFGHIJ'))
+    compare_slice_to_list(list(b[::2].s), list('ACEGI'))
+    compare_slice_to_list(list(b[::2][1:].s), list('CEGI'))
 
 
 def test_getattr_subclass():

--- a/tests.py
+++ b/tests.py
@@ -122,13 +122,9 @@ def test_slice_of_slice_of_slice_of_slice():
     compare_slice_to_list(slice2, list('cegi'))
     slice3 = slice2[:]
     compare_slice_to_list(slice3, list('cegi'))
-    print('define slice4')
     slice4 = slice3[:-1]
-    print('compare slice4')
     compare_slice_to_list(slice4, list('ceg'))
-    print('define slice4a')
     slice4a = slice3[::-1]
-    print('compare slice4a')
     compare_slice_to_list(slice4a, list('igec'))
 
 


### PR DESCRIPTION
This fixes the issue raised in #12, now indexed attributes are propagated correctly through pipelines.

Additionally, there was a bug: the indices of the SliceableAttribute were using the same generator as the ancestor Slicerator. This gave some unexpected results (as in the example of `test_getattr`):

```
list(a.s)  # returns ['A', 'B', ..., 'J']
list(a.s)  # returns []
```

This is now fixed by giving SliceableAttribute an independent copy of the indices generator.
