### PR TITLE
FIX Pipelines that act inplace

### DIFF
--- a/slicerator.py
+++ b/slicerator.py
@@ -362,7 +362,10 @@ def _index_generator(new_indices, old_indices):
 
 class Pipeline(object):
     def __init__(self, ancestor, proc_func, propagate_attrs=None):
-        """A class to support lazy function evaluation on an iterable
+        """A class to support lazy function evaluation on an iterable.
+
+        When a ``Pipeline`` object is indexed, it returns an element of its
+        ancestor modified with a process function.
 
         Parameters
         ----------
@@ -371,6 +374,20 @@ class Pipeline(object):
             function that processes data returned by Slicerator. The function
             acts element-wise and is only evaluated when data is actually
             returned
+
+        Example
+        -------
+        Construct the pipeline object that multiplies elements by two:
+        >>> ancestor = [0, 1, 2, 3, 4]
+        >>> times_two = Pipeline(ancestor, lambda x: 2*x)
+
+        Whenever the pipeline object is indexed, it takes the correct element
+        from its ancestor, and then applies the process function.
+        >>> times_two[3]  # returns 6
+
+        See also
+        --------
+        pipeline
         """
         # when list of propagated attributes are given explicitly,
         # take this list and ignore the class definition
@@ -434,18 +451,23 @@ class Pipeline(object):
         # When deserializing, restore the Pipeline
         return self.__init__(data_as_list, lambda x: x)
 
-def pipeline(func):
-    """Decorator to make function aware of Slicerator objects.
 
-    When the function is applied to a Slicerator, it
-    returns another lazily-evaluated, Slicerator object.
+def pipeline(func):
+    """Decorator to enable lazy evaluation of a function.
+
+    When the function is applied to a Slicerator or Pipeline object, it
+    returns another lazily-evaluated, Pipeline object.
 
     When the function is applied to any other object, it falls back on its
-    normal behavhior.
+    normal behavior.
 
     Returns
     -------
-    processed_images : Slicerator
+    processed_images : Pipeline
+
+    See also
+    --------
+    Pipeline
 
     Example
     -------
@@ -455,7 +477,7 @@ def pipeline(func):
     ...      return image[channel, :, :]
     ...
 
-    Passing a Slicerator the function returns another Slicerator
+    Passing a Slicerator the function returns a Pipeline
     that "lazily" applies the function when the images come out. Different
     functions can be applied to the same underlying images, creating
     independent objects.
@@ -490,7 +512,7 @@ def pipeline(func):
         process.__doc__ = ''
     process.__doc__ = ("This function has been made lazy. When passed\n"
                        "a Slicerator, it will return a \n"
-                       "new Slicerator of the results. When passed \n"
+                       "Pipeline of the results. When passed \n"
                        "any other objects, its behavior is "
                        "unchanged.\n\n") + process.__doc__
     process.__name__ = func.__name__

--- a/slicerator.py
+++ b/slicerator.py
@@ -317,6 +317,10 @@ def key_to_indices(key, length):
         # allow negative indexing
         if -length < key < 0:
             return length + key, None
+        elif 0 <= key < length:
+            return key, None
+        else:
+            raise IndexError('index out of range')
 
     # in all other case, just return the key and let user deal with the type.
     return key, None
@@ -401,6 +405,9 @@ class Pipeline(object):
 
     def __len__(self):
         return self._ancestor.__len__()
+
+    def __iter__(self):
+        return (self._get(i) for i in range(len(self)))
 
     def __getitem__(self, i):
         """for data access"""

--- a/tests.py
+++ b/tests.py
@@ -163,6 +163,19 @@ def _a_to_z(letter):
     else:
         return letter
 
+@pipeline
+def append_zero_inplace(list_obj):
+    list_obj.append(0)
+    return list_obj
+
+
+def test_inplace_pipeline():
+    n_mutable = Slicerator([list([i]) for i in range(10)])
+    appended = append_zero_inplace(n_mutable)
+
+    assert_equal(appended[5], [5, 0])  # execute the function
+    assert_equal(n_mutable[5], [5])    # check the original
+
 
 def test_pipeline_simple():
     capitalize = pipeline(_capitalize)


### PR DESCRIPTION
This fixes the case in which a pipeline function acts inplace which can lead to issues if there is some muteable value in the slicerator tree.
