### PR TITLE
Drop some references to `_version.py`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-_version.py export-subst
+_slicerator_version.py export-subst

--- a/_slicerator_version.py
+++ b/_slicerator_version.py
@@ -38,7 +38,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "None"
-    cfg.versionfile_source = "_version.py"
+    cfg.versionfile_source = "_slicerator_version.py"
     cfg.verbose = False
     return cfg
 


### PR DESCRIPTION
Seems there was an old `_version.py`, which was renamed to `_slicerator_version.py`, but a few `_version.py` strings escaped the renaming. So this tidies them up.

ref: https://github.com/soft-matter/slicerator/commit/06cb18068e6197d86f7ff750e67c041fe6f7f0f8