### PR TITLE
PERF: Use list(range) instead of range

### DIFF
--- a/slicerator/__init__.py
+++ b/slicerator/__init__.py
@@ -75,12 +75,12 @@ class Slicerator(object):
         if indices is None and length is None:
             try:
                 length = len(ancestor)
-                indices = range(length)
+                indices = list(range(length))
             except TypeError:
                 raise ValueError("The length parameter is required in this "
                                  "case because len(ancestor) is not valid.")
         elif indices is None:
-            indices = range(length)
+            indices = list(range(length))
         elif length is None:
             try:
                 length = len(indices)


### PR DESCRIPTION
This addresses #31 . I've confirmed that for large sequences it reduces slicerator's overhead by at least a few orders of magnitude.