### PR TITLE
`Iterable` was moved to `collections.abc`

### DIFF
--- a/slicerator/__init__.py
+++ b/slicerator/__init__.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 from six.moves import range
-import collections
+import collections.abc
 import itertools
 from functools import wraps
 from copy import copy
@@ -232,7 +232,7 @@ class Slicerator(object):
     def __getitem__(self, key):
         """for data access"""
         if not (isinstance(key, slice) or
-                isinstance(key, collections.Iterable)):
+                isinstance(key, collections.abc.Iterable)):
             return self._get(self._map_index(key))
         else:
             rel_indices, new_length = key_to_indices(key, len(self))
@@ -284,7 +284,7 @@ def key_to_indices(key, length):
         indices = range(start, stop, step)
         return indices, len(indices)
 
-    if isinstance(key, collections.Iterable):
+    if isinstance(key, collections.abc.Iterable):
         # if the input is an iterable, doing 'fancy' indexing
         if hasattr(key, '__array__') and hasattr(key, 'dtype'):
             if key.dtype == bool:
@@ -484,7 +484,7 @@ class Pipeline(object):
     def __getattr__(self, name):
         # to avoid infinite recursion, always check if public field is there
         pa = self.__dict__.get('_propagate_attrs', [])
-        if not isinstance(pa, collections.Iterable):
+        if not isinstance(pa, collections.abc.Iterable):
             raise TypeError('_propagate_attrs is not iterable')
         if name in pa:
             for a in self._get_prop_ancestors():
@@ -711,7 +711,7 @@ def index_attr(func):
     @wraps(func)
     def wrapper(obj, key, *args, **kwargs):
         indices = key_to_indices(key, len(obj))[0]
-        if isinstance(indices, collections.Iterable):
+        if isinstance(indices, collections.abc.Iterable):
             return (func(obj, i, *args, **kwargs) for i in indices)
         else:
             return func(obj, indices, *args, **kwargs)
@@ -757,7 +757,7 @@ class SliceableAttribute(object):
 
     def __call__(self, key, *args, **kwargs):
         if not (isinstance(key, slice) or
-                isinstance(key, collections.Iterable)):
+                isinstance(key, collections.abc.Iterable)):
             return self._get(self._map_index(key), *args, **kwargs)
         else:
             rel_indices, new_length = key_to_indices(key, len(self))


### PR DESCRIPTION
Python 3.10 removed the `Iterable` from `collections`. This commit replaces all occurrences of `collections.Iterable` with `collections.abc.Iterable`.